### PR TITLE
Fix Android categoryColorList, screw up iOS categoryColorList

### DIFF
--- a/app/components/CategoryColor/index.js
+++ b/app/components/CategoryColor/index.js
@@ -22,10 +22,11 @@ class CategoryColor extends React.Component {
 
   categoryColorStyles () {
     let { isActive, color } = this.props
+    const flexGrowValue = 1.075
     let categoryStyles = [styles.color, {backgroundColor: color, height: this.state.height}]
     if (isActive) {
       this.handleAnimation('up')
-      return categoryStyles
+      return [...categoryStyles, { flexGrow: flexGrowValue }]
     }
     this.handleAnimation('down')
     return categoryStyles

--- a/app/components/CategoryColor/styles.js
+++ b/app/components/CategoryColor/styles.js
@@ -2,7 +2,7 @@ import { StyleSheet } from 'react-native'
 
 const styles = StyleSheet.create({
   color: {
-    flexGrow: 1.075,
+    flexGrow: 1,
     height: 3
   }
 })


### PR DESCRIPTION
![](https://media.giphy.com/media/OOZLyBA9Euq2I/giphy.gif)

No Android fica sem os espaços entre as cores, no iOS fica, como vamos lançar primeiro pro Android, [criei um card no Trello](https://trello.com/c/ScP7KLnT/309-categorycolorlist-espacos-bizarros) para posteriormente achar uma solução para o iOS.